### PR TITLE
Updated to match new CLIFp syntax

### DIFF
--- a/FlashpointShortcutMaker.vbs
+++ b/FlashpointShortcutMaker.vbs
@@ -8,18 +8,20 @@ If Not FileExists(clifp) Then
 	WScript.Quit
 End If
 Set wshShell = CreateObject("WScript.Shell")
-desktopDir = wshShell.ExpandEnvironmentStrings("%HOMEDRIVE%%HOMEPATH%") & "\Desktop"
+desktopDir = wshShell.ExpandEnvironmentStrings("%HOMEDRIVE%%HOMEPATH%") & "\Desktop\"
 
-shortcutName = ""
-Do While Not IsKosherFilename(shortcutName) 
-	shortcutName = InputBox("Enter a name for your shortcut.", "Create Flashpoint Shortcut")
-	If shortcutName = "" Then
-		WScript.Quit
-	ElseIf Not IsKosherFilename(shortcutName) Then
-		msgbox "A shortcut cannot contain any of the following characters: \/:*?""<>| Try again."
-    End If
-Loop
+' The shortcut name (uses game title) can now automatically be pulled from database by CLIFp
+'shortcutName = ""
+'Do While Not IsKosherFilename(shortcutName) 
+' 	shortcutName = InputBox("Enter a name for your shortcut.", "Create Flashpoint Shortcut")
+'	If shortcutName = "" Then
+'		WScript.Quit
+'	ElseIf Not IsKosherFilename(shortcutName) Then
+'		msgbox "A shortcut cannot contain any of the following characters: \/:*?""<>| Try again."
+'    End If
+'Loop
 
+' Prompt user for game ID. CLIFp will validate this UUID is present in the database
 gameID = ""
 Do While Not IsUUID(gameID) 
 	gameID = InputBox("Enter the ID of the game or animation.", "Create Flashpoint Shortcut")
@@ -30,16 +32,20 @@ Do While Not IsUUID(gameID)
 	End If
 Loop
 
-shortcutFile = desktopDir & "\" & shortcutName & ".lnk"
-clifpArgs = "--quiet --auto " & gameID
+' Build arguments and launch command
+clifpIDArg = "--id=""" & gameID & """" 
+clifpPathArg = "--path=""" & desktopDir & "\"""
+clifpLinkCmd = """" & clifp & """" & "link " & clifpIDArg & " " & clifpPathArg
 
-Set shortcutObj = wshShell.CreateShortcut(shortcutFile)
-	shortcutObj.TargetPath = clifp
-	shortcutObj.Arguments = clifpArgs
-	shortcutObj.IconLocation = fpLauncher
-shortcutObj.Save
-msgBox "Shortcut saved!"
+' Create shortcut with CLIFp
+statusCode = wshShell.Run(clifpLinkCmd, 1, true)
 
+' Print success message. CLIFp will handle error messages if required
+If statusCode = 0 Then
+	msgBox "Shortcut saved!"
+End	If
+
+' Functions
 Function FileExists(FilePath)
 	Set fso = CreateObject("Scripting.FileSystemObject")
 	If fso.FileExists(FilePath) Then

--- a/README.md
+++ b/README.md
@@ -10,5 +10,4 @@ This is a simple VBScript tool to create shortcuts to individual games/animation
 1. Open Flashpoint Launcher and find the game/animation that you want to create a shortcut for.
 2. Right-click the game/animation and click "Copy Game UUID".
 3. Double-click FlashpointShortcutMaker.vbs.
-4. Type a name for your shortcut, then click OK. Do not use invalid filename characters such as slashes `/ \` or question marks `?`.
-5. Paste the UUID of the game/animation that you copied in step 2. Click OK, and the shortcut will appear on your desktop!
+4. Paste the UUID of the game/animation that you copied in step 2. Click OK, and the shortcut will appear on your desktop!


### PR DESCRIPTION
- CLIFp now can create the shortcut itself so it is used to validate
  the ID actually belongs to a game
- CLIFp will automatically set the shortcut name to the title of the
  game that the ID belongs to when passed a directory as the shortcut
  path (in this case the Desktop), so prompting for the shortcut name
  is no longer required
- Removed the usage of the -q switch since the errant Start/Stop
  entries in `services.json` that it was used to avoid reporting in FP9
  have been removed in FP10